### PR TITLE
Excluded report/ from Apache RAT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,7 @@
           <artifactId>apache-rat-plugin</artifactId>
           <configuration>
             <excludes>
+              <exclude>report/**</exclude>
               <exclude>src/test/resources/images/**/*</exclude>
               <exclude>src/test/resources/IMAGING-*/*</exclude>
               <exclude>src/test/data/**/*.xpm</exclude>


### PR DESCRIPTION
## Context
Apache RAT is a project to audit licenses and was blocking the github actions.

## Changes
- Excluded `report/` folder from rat analysis.