### PR TITLE
[FIX] Fix Tests in `ubuntu` - `getValidPngImages` Returns images by filename

### DIFF
--- a/src/test/java/org/apache/commons/imaging/formats/png/PngWriterTest.java
+++ b/src/test/java/org/apache/commons/imaging/formats/png/PngWriterTest.java
@@ -16,21 +16,23 @@
  */
 package org.apache.commons.imaging.formats.png;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.apache.commons.imaging.Imaging;
+import org.apache.commons.imaging.palette.Palette;
+import org.apache.commons.imaging.palette.PaletteFactory;
+import org.apache.commons.imaging.palette.SimplePalette;
+import org.junit.jupiter.api.Test;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import org.apache.commons.imaging.Imaging;
-import org.apache.commons.imaging.palette.Palette;
-import org.apache.commons.imaging.palette.PaletteFactory;
-import org.apache.commons.imaging.palette.SimplePalette;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for class {@link PngWriter}.
@@ -49,19 +51,20 @@ public class PngWriterTest extends AbstractPngTest {
         }
     }
 
-    private List<File> getValidPngImages() throws IOException {
+    private HashMap<String, File> getValidPngImages() throws IOException {
         final List<File> result = new ArrayList<>();
         for (final File imageFile : getPngImages()) {
             if (!isInvalidPngTestFile(imageFile)) {
                 result.add(imageFile);
             }
         }
-        return result;
+        return result.stream()
+                .collect(Collectors.toMap(File::getName, file -> file, (existing, replacement) -> existing, HashMap::new));
     }
 
     @Test
     public void testNullParameters() throws IOException {
-        final File imageFile = getValidPngImages().get(0);
+        final File imageFile = getValidPngImages().get("Oregon Scientific DS6639 - DSC_0307 - small.png");
 
         final BufferedImage image = Imaging.getBufferedImage(imageFile);
 
@@ -75,7 +78,7 @@ public class PngWriterTest extends AbstractPngTest {
 
     @Test
     public void testPaletteFactory() throws IOException {
-        final File imageFile = getValidPngImages().get(0);
+        final File imageFile = getValidPngImages().get("Oregon Scientific DS6639 - DSC_0307 - small.png");
 
         final BufferedImage image = Imaging.getBufferedImage(imageFile);
         final PngImagingParameters params = new PngImagingParameters();


### PR DESCRIPTION
## Context

After trying running tests in an `ubuntu` based action, the test`testPaletteFactory` was raising an error since it was using an image as fixture that was coming from a list of images. Depending on how that list was sorted, tests could fail, and that was happened in ubuntu action.

## Changes
- Make `getValidPngImages` return a map of images by filenames
- Added `get("Oregon Scientific DS6639 - DSC_0307 - small.png");` to `testPaletteFactory`, `testNullParameters`