### PR TITLE
UNISA-16: Fix BitArrayOutputStream

### DIFF
--- a/src/main/java/org/apache/commons/imaging/formats/pcx/PcxWriter.java
+++ b/src/main/java/org/apache/commons/imaging/formats/pcx/PcxWriter.java
@@ -170,6 +170,7 @@ class PcxWriter {
             bos.write(12);
             for (int i = 0; i < 256; i++) {
                 int rgb;
+                assert palette != null;
                 if (i < palette.length()) {
                     rgb = palette.getEntry(i);
                 } else {

--- a/src/main/java/org/apache/commons/imaging/formats/tiff/itu_t4/T4AndT6Compression.java
+++ b/src/main/java/org/apache/commons/imaging/formats/tiff/itu_t4/T4AndT6Compression.java
@@ -327,7 +327,9 @@ public final class T4AndT6Compression {
             // EOFB
             T4_T6_Tables.EOL.writeBits(outputStream);
             T4_T6_Tables.EOL.writeBits(outputStream);
-            return outputStream.toByteArray();
+            byte[] _outputStream = outputStream.toByteArray();
+            outputStream.close();
+            return _outputStream;
         } catch (final IOException ioException) {
             throw new ImagingException("I/O error", ioException);
         }


### PR DESCRIPTION
**Description**

Connections, streams, files, and other classes that implement the Closeable interface or its super-interface, AutoCloseable, needs to be closed after use.

**Changes**

- Close stream after use it.
- Adding assert in pallet if is null