### PR TITLE
[Fix CI] Remove Owasp DC for SonarCloud and SpotBug workflow

### DIFF
--- a/.github/workflows/sonar_cloud.yml
+++ b/.github/workflows/sonar_cloud.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=MerendaFrancoN_commons-imaging-dependability
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=MerendaFrancoN_commons-imaging-dependability -DskipDependencyCheck=true

--- a/.github/workflows/spotbug-analysis.yml
+++ b/.github/workflows/spotbug-analysis.yml
@@ -18,7 +18,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build with Maven
-        run: mvn -B verify spotbugs:spotbugs
+        run: mvn -B verify spotbugs:spotbugs -DskipDependencyCheck=true
       - uses: jwgmeligmeyling/spotbugs-github-action@master
         with:
           path: '**/spotbugsXml.xml'


### PR DESCRIPTION
# Context

Owasp DC takes a huge amount of time to run in the CI so to avoid consuming unnecessary time in SonarCloud and Spotbug Workflow actions, was removed

# Changes
- Added `-DskipDependencyCheck=true` to SonarCloud and Spotbug workflows.