### PR TITLE
[Dependencies] Add evosuite

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
     - name: Build with Maven
-      run: mvn --show-version --batch-mode --no-transfer-progress test jacoco:report -DskipDependencyCheck=true
+      run: mvn --show-version --batch-mode --no-transfer-progress test jacoco:report -DskipDependencyCheck=true -DrunEvosuite=false
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -52,4 +52,4 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
     - name: Build with Maven
-      run: mvn --show-version --batch-mode --no-transfer-progress -DskipDependencyCheck=true
+      run: mvn --show-version --batch-mode --no-transfer-progress -DskipDependencyCheck=true -DrunEvosuite=false

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
 #        os: [windows-latest, ubuntu-latest]
 #        os: [windows-latest, macos-latest]
         os: [windows-latest]
-        java: [ 8, 11, 17, 21 ]
+        java: [ 8 ]
         experimental: [false]
 #        include:
 #          - java: 22-ea

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
 #        os: [windows-latest, ubuntu-latest]
 #        os: [windows-latest, macos-latest]
         os: [windows-latest]
-        java: [ 8 ]
+        java: [ 8, 11, 17, 21 ]
         experimental: [false]
 #        include:
 #          - java: 22-ea

--- a/pom.xml
+++ b/pom.xml
@@ -209,19 +209,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.evosuite.plugins</groupId>
-                <artifactId>evosuite-maven-plugin</artifactId>
-                <version>1.0.6</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare</goal>
-                        </goals>
-                        <phase>process-test-classes</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>1.8</version>
@@ -556,6 +543,32 @@
                                 <goals>
                                     <goal>check</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>evosuite-profile</id>
+            <activation>
+                <property>
+                    <name>runEvosuite</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.evosuite.plugins</groupId>
+                        <artifactId>evosuite-maven-plugin</artifactId>
+                        <version>1.0.6</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare</goal>
+                                </goals>
+                                <phase>process-test-classes</phase>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>org.evosuite.runtime.InitializingListener</value>
+                        </property>
+                    </properties>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -200,6 +208,38 @@
                     </targetTests>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.evosuite.plugins</groupId>
+                <artifactId>evosuite-maven-plugin</artifactId>
+                <version>1.0.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare</goal>
+                        </goals>
+                        <phase>process-test-classes</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>add-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>.evosuite/evosuite-tests</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
@@ -242,24 +282,17 @@
                             <exclude>src/test/data/**/*.hdr</exclude>
                             <exclude>src/main/resources/org/apache/commons/imaging/formats/xpm/rgb.txt</exclude>
                             <exclude>.asf.yaml</exclude>
+                            <exclude>.evosuite/**</exclude>
+                            <exclude>.scaffolding_list.tmp</exclude>
+                            <exclude>src/test/java/org/apache/commons/imaging/ImageFormats_ESTest_scaffolding.java
+                            </exclude>
+                            <exclude>src/test/java/org/apache/commons/imaging/ImageInfo_ESTest_scaffolding.java
+                            </exclude>
                             <exclude>spotbugs-security-exclude.xml</exclude>
                             <exclude>spotbugs-security-include.xml</exclude>
                             <exclude>.github/workflows/spotbug-analysis.yml</exclude>
                         </excludes>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>com.github.spotbugs</groupId>
-                    <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.8.1.0</version>
-                    <dependencies>
-                        <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
-                        <dependency>
-                            <groupId>com.github.spotbugs</groupId>
-                            <artifactId>spotbugs</artifactId>
-                            <version>4.8.2</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -274,6 +307,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -297,6 +336,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.13.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.evosuite</groupId>
+            <artifactId>evosuite-standalone-runtime</artifactId>
+            <version>1.0.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -416,6 +461,10 @@
                         <exclude>src/test/data/**/*.hdr</exclude>
                         <exclude>src/main/resources/org/apache/commons/imaging/formats/xpm/rgb.txt</exclude>
                         <exclude>.asf.yaml</exclude>
+                        <exclude>.evosuite/**</exclude>
+                        <exclude>.scaffolding_list.tmp</exclude>
+                        <exclude>src/test/java/org/apache/commons/imaging/ImageFormats_ESTest_scaffolding.java</exclude>
+                        <exclude>src/test/java/org/apache/commons/imaging/ImageInfo_ESTest_scaffolding.java</exclude>
                         <exclude>spotbugs-security-exclude.xml</exclude>
                         <exclude>spotbugs-security-include.xml</exclude>
                         <exclude>.github/workflows/spotbug-analysis.yml</exclude>


### PR DESCRIPTION
# Context 
We need to add Automated Tests Generation by some tools like Evosuite and Randoop 

# Changes
- Added evosuite dependencies following the [tutorial](https://www.evosuite.org/documentation/tutorial-part-2/)
- Added Randoop usage
- Added evosuite profile in pom to avoid that get's running in the CI. Allowed only for local.

# Usage
- EvoSuite Tests Generation for specific classes - Only Runs with Java 8 !
  - Syntax: `mvn -DmemoryInMB=<amount_mb> -Dcores=<number_of_cores> evosuite:generate evosuite:export test -DcutsFile=<path_to_file_where_specific_classes_are_defined.txt>`
  - Example: `mvn -DmemoryInMB=2000 -Dcores=2 evosuite:generate evosuite:export test -DcutsFile=.evosuite/cutsFile.txt`
  
Randoop:
  - Download last version [jar](https://randoop.github.io/randoop/manual/index.html#getting_randoop) 
  - Example: `java -Xmx3000m -classpath /Users/stormtrooper/SoftwareProjects/commons-imaging/target/commons-imaging-1.0-SNAPSHOT.jar:/Users/stormtrooper/Downloads/randoop-4.3.2/randoop-all-4.3.2.jar randoop.main.Main gentests --testclass=org.apache.commons.imaging.ImageInfo --output-limit=100`

